### PR TITLE
Add scikit learn Choosing the Right Estimator page link

### DIFF
--- a/lessons/02_ML_intro/02_scikit_learn.md
+++ b/lessons/02_ML_intro/02_scikit_learn.md
@@ -36,6 +36,8 @@ That `create → fit → predict` pattern is what makes scikit-learn so pleasant
 
 If you'd like to explore the official documentation (highly recommended!), visit: [scikit-learn.org](https://scikit-learn.org/stable/)
 
+In particular, this page provides a summary of the available models and when to use them: [Choosing the Right Estimator](https://scikit-learn.org/stable/machine_learning_map.html)
+
 ### Seeing the API in action
 
 Let's warm up with a tiny example. Imagine you own a bakery and want to predict cupcake sales based on the temperature outside. We'll use *linear regression* for that. We'll take a deeper dive into linear regression in the next lesson. Don't worry about the details, we're just looking at the pattern here.


### PR DESCRIPTION
Added a link to the scikit learn choosing the right estimator page.  This is a great summary of the models which are available, how much data is needed and what their applications are.  It's something the students see.