### PR TITLE
Keyword RAG fix

### DIFF
--- a/assignments/06_AI_augmentation.md
+++ b/assignments/06_AI_augmentation.md
@@ -153,7 +153,7 @@ def simple_keyword_retrieval(query, documents, verbose=True):
 Run `simple_keyword_retrieval` with `verbose=True` on the query and documents below. Print the name of the selected document.
 
 ```python
-query = "What are your hours on the weekend?"
+query = "What are your hours on weekends?"
 
 documents = {
     "menu.txt": "We serve espresso, lattes, cappuccinos, and cold brew. Pastries include croissants and muffins baked fresh daily. Oat milk and almond milk are available.",


### PR DESCRIPTION
Changed the query so it works as advertised. The original query 'What are your hours on the weekend?' did not match the document as advertised. Changed it to '"What are your hours on weekends'.